### PR TITLE
[☢️DONT MERGE] Add crosshair hook to generic viewers

### DIFF
--- a/camstack/viewers/generic_viewer_backend.py
+++ b/camstack/viewers/generic_viewer_backend.py
@@ -62,6 +62,7 @@ class GenericViewerBackend:
         self.flag_data_init = False
         self.flag_averaging = False
         self.flag_non_linear = False
+        self.flag_cross = False
 
         ### COLORING
         self.cmap_id = 1
@@ -82,6 +83,7 @@ class GenericViewerBackend:
                 pgm_ct.K_l: self.toggle_scaling,
                 pgm_ct.K_z: self.toggle_crop,
                 pgm_ct.K_v: self.toggle_averaging,
+                pgm_ct.K_c: self.toggle_cross,
                 pgm_ct.K_UP: partial(self.steer_crop, pgm_ct.K_UP),
                 pgm_ct.K_DOWN: partial(self.steer_crop, pgm_ct.K_DOWN),
                 pgm_ct.K_LEFT: partial(self.steer_crop, pgm_ct.K_LEFT),
@@ -112,6 +114,12 @@ class GenericViewerBackend:
             self.flag_non_linear = (self.flag_non_linear + 1) % 3
         else:
             self.flag_non_linear = value
+
+    def toggle_cross(self, state: bool=None):
+        if state is None:
+            state = not self.flag_cross
+        self.flag_cross = bool(state)
+
 
     def toggle_crop(self, which: int = None) -> None:
         if which is None:

--- a/camstack/viewers/generic_viewer_frontend.py
+++ b/camstack/viewers/generic_viewer_frontend.py
@@ -182,6 +182,14 @@ class GenericViewerFrontend:
                 self.lbl_t_minmax.rectangle,
         ]
 
+    def _plot_cross(self):
+        if self.backend_obj.flag_cross:
+            xc, yc = self.backend_obj.CROP_CENTER_SPOT
+            xw, yw = self.data_disp_size
+            color = pygame.Color("#4AC985")
+            pygame.draw.line(self.pg_datasurface, color, (0, yc), (xw, yc), 1)
+            pygame.draw.line(self.pg_datasurface, color, (xc, 0), (xc, yw), 1)
+
     def register_backend(self, backend: GenericViewerBackend) -> None:
 
         self.backend_obj = backend
@@ -281,6 +289,7 @@ class GenericViewerFrontend:
 
         # Manage labels
         self._update_labels_postloop()
+        self._plot_cross()
 
         self.pg_screen.blit(self.pg_datasurface, self.pg_data_rect)
         self.pg_updated_rects += [self.pg_data_rect]


### PR DESCRIPTION
As title says, adds a crosshair centered on the crop center.

Here's a screenshot of it working 
![Screen Shot 2023-03-22 at 20 17 41](https://user-images.githubusercontent.com/14099459/227120005-821ea127-464b-4340-aad0-18f680b431c3.png)

> ☢️ Don't Merge until this is addressed: 
> 
> Note, this doesn't seem to work with different binning, so my calculation [here](https://github.com/scexao-org/camstack/blob/e2bb79825b06e2e801d60f6c8c86046552e3299b/camstack/viewers/generic_viewer_frontend.py#L187-L188) is botched, please advise.

I'm mostly just trying to get a feel for this pygame stuff, hopefully I've got things in the right places. I would like to add more of the generic features, like the centroid bullseye and other features that look easy to set up.
